### PR TITLE
Update Dockerfile based on ocp-build-data in master

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,7 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/node-problem-detector-operator
 COPY . .
 RUN go build ./cmd/node-problem-detector-operator
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/openshift/node-problem-detector-operator/node-problem-detector-operator /usr/bin/


### PR DESCRIPTION
The original [PR](https://github.com/openshift/node-problem-detector-operator/pull/17) went to the `release-4.6` branch which I believe was incorrect. `release-4.6` is still supposed to be fast-forwarded from master, so this change should have gone to master instead.

/cc @alvaroaleman @joelsmith @jupierce 